### PR TITLE
Adapt reading of validation data

### DIFF
--- a/data/validation_data/validation_data.csv
+++ b/data/validation_data/validation_data.csv
@@ -1,79 +1,33 @@
 requirements_path,cv_path,t1,t2,grat
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-14.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-15.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-17.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-18.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-19.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-20.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-21.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-22.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-23.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-24.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-25.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-26.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-27.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-28.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-29.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/ABS/B-30.pdf.json,0,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-1.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-10.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-11.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-12.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-13.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-3.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-6.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-7.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T1/B-9.pdf.json,1,0,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T2/B-2.pdf.json,1,1,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T2/B-4.pdf.json,1,1,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T2/B-5.pdf.json,1,1,0
-data/validation_data/11425/parsed_data/B-Stellenbeschreibung.docx.json,data/validation_data/11425/parsed_data/T2/B-8.pdf.json,1,1,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/02 CV Deutsch Richter.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/Ahmed_Salahiya_Lebenslauf.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/CV Daniel Hofer.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/CV_Jochen_Silberbauer.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/CV_Vasilis_Apostolopoulos.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/Lebenslauf Gaschl.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/Lebenslauf.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/Lebenslauf_202501.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/Mostafa_Elnagdy__Resume__Sep_24_.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/ABS/___CV_Matthaeus Kurz_EN_new.pdf.json,0,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/CV Sophie Albrecht_102024.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/CV_Daniel_Altendorfer_CV_2022_09_08.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/CV_Schmidinger_2025.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/GEORG_NAGL_CV_11627_KAM_EC.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/LEBENM_FH.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/Lebenslauf_Christian_Schwaiger_NEU.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/Lebenslauf_Hlavacek_Florian.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T1/Lebenslauf_Schuettengruber.pdf.json,1,0,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T2/Lebenslauf_KaurinovicJuro_Vertrieb.pdf.json,1,1,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/T2/Nageler Manuel 2024.pdf.json,1,1,0
-data/validation_data/11627/parsed_data/AKP_11627_Enerserv Getec_Key Account Manager_12_2024.docx.json,data/validation_data/11627/parsed_data/GRAT/CV_Marjanovic_Antonio.pdf.json,1,1,1
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-17.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-18.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-19.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-20.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-21.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-22.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-23.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-24.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-25.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-26.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-27.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-28.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/ABS/C-30.pdf.json,0,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-10.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-11.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-12.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-13.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-14.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-15.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T1/C-9.pdf.json,1,0,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-1.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-2.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-4.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-5.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-6.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-7.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/T2/C-8.pdf.json,1,1,0
-data/validation_data/11877/parsed_data/C-Stellenbeschreibung.docx.json,data/validation_data/11877/parsed_data/GRAT/C-3.pdf.json,1,1,1
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-14.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-15.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-16.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-17.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-18.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-19.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-20.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-21.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-22.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-23.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-24.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-25.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-26.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-27.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-28.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-29.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-30.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-31.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/ABS/B-32.pdf,0,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-1.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-10.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-11.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-12.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-13.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-3.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-6.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-7.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T1/B-9.pdf,1,0,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T2/B-2.pdf,1,1,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T2/B-4.pdf,1,1,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T2/B-5.pdf,1,1,0
+data/validation_data/11425/raw_data/B-Stellenbeschreibung.docx,data/validation_data/11425/raw_data/T2/B-8.pdf,1,1,0

--- a/definitions.py
+++ b/definitions.py
@@ -321,21 +321,21 @@ class CVMatchingPipeline:
 
             print("Processing CV:", cv_path)
 
-            # try:
-            cv_data = self.CVParsingStep.run(cv_path, args=args)
-            score, scores = self.MatchingStep.run(cv_data, requirements, args=args)
+            try:
+                cv_data = self.CVParsingStep.run(cv_path, args=args)
+                score, scores = self.MatchingStep.run(cv_data, requirements, args=args)
 
-            results.append({
-                "cv_path": cv_path,
-                "score": score,
-                **scores
-            })
-            # except Exception as e:
-            #     print(f"Error processing CV {cv_path}: {e}")
-            #     results.append({
-            #         "cv_path": cv_path,
-            #         "score": score,
-            #         **scores
-            #     })
+                results.append({
+                    "cv_path": cv_path,
+                    "score": score,
+                    **scores
+                })
+            except Exception as e:
+                print(f"Error processing CV {cv_path}: {e}")
+                results.append({
+                    "cv_path": cv_path,
+                    "score": score,
+                    **scores
+                })
 
         return results

--- a/parse_cv/read_llm_parsed_cv.py
+++ b/parse_cv/read_llm_parsed_cv.py
@@ -8,12 +8,18 @@ class ReadLLMParsedCV(CVParsingStep):
         Read parsed CV from LLM
         
         :param self: 
-        :param cv_path: OS Path to CV (.json)
+        :param cv_path: OS Path to CV (.pdf or .docx)
         :type cv_path: str
         :param args: Optional arguments
         :return: CV Data
         :rtype: CVData
         """
-        with open(cv_path, "r", encoding="utf-8") as f:
-            cv_data = json.load(f)
-        return cv_data
+
+        cv_path_parsed = cv_path.replace("raw_data", "parsed_data").replace(".docx", ".docx.json").replace(".pdf", ".pdf.json")
+
+        try:
+            with open(cv_path_parsed, "r", encoding="utf-8") as f:
+                cv_data = json.load(f)
+            return cv_data
+        except FileNotFoundError as e:
+            print(f"File {cv_path_parsed} does not exist: {e}")

--- a/parse_requirements/read_llm_parsed_requirement.py
+++ b/parse_requirements/read_llm_parsed_requirement.py
@@ -8,12 +8,15 @@ class ReadLLMParsedRequirement(CVParsingStep):
         Read parsed Requirement from LLM
         
         :param self: 
-        :param req_path: OS Path to Requirement (.json)
+        :param req_path: OS Path to Requirement (.docx)
         :type req_path: str
         :param args: Optional arguments
         :return: Requirements Data
         :rtype: RequirementsData
         """
-        with open(req_path, "r", encoding="utf-8") as f:
+
+        req_path_parsed = req_path.replace("raw_data", "parsed_data").replace(".docx", ".docx.json")
+
+        with open(req_path_parsed, "r", encoding="utf-8") as f:
             req_data = json.load(f)
         return req_data

--- a/validation/read_validation_data.py
+++ b/validation/read_validation_data.py
@@ -13,13 +13,13 @@ entries = []
 
 for dir in os.listdir(VALIDATION_DATA_DIR):
 
-    dir_path = os.path.join(VALIDATION_DATA_DIR, dir, "parsed_data")
+    dir_path = os.path.join(VALIDATION_DATA_DIR, dir, "raw_data")
 
     if not os.path.exists(dir_path):
         continue
 
     requirements = next(
-        (os.path.join(dir_path, f) for f in os.listdir(dir_path) if f.endswith(".json")),
+        (os.path.join(dir_path, f) for f in os.listdir(dir_path) if f.endswith(".docx")),
         None
     )
 
@@ -34,7 +34,7 @@ for dir in os.listdir(VALIDATION_DATA_DIR):
             continue
 
         for file in os.listdir(folder_path):
-            if file.endswith(".json"):
+            if file.endswith(".pdf"):
                 entries.append({
                     "requirements_path": requirements,
                     "cv_path": os.path.join(folder_path, file),


### PR DESCRIPTION
Validation data now reads the raw_path and only the temporary function for reading LLM-parsed data